### PR TITLE
New functionality: de-serialize from JSON string to Event and MessageResponse

### DIFF
--- a/src/main/java/net/hawry/messaging/core/webhook/Event.java
+++ b/src/main/java/net/hawry/messaging/core/webhook/Event.java
@@ -1,6 +1,10 @@
 package net.hawry.messaging.core.webhook;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
 import com.google.gson.annotations.SerializedName;
+
+import net.hawry.messaging.exceptions.InvalidJsonException;
 
 public class Event {
   @SerializedName("object") String object;
@@ -12,5 +16,16 @@ public class Event {
 
   public Entry[] getEntries() {
     return this.entry;
+  }
+
+  public static Event fromJson(String json) throws InvalidJsonException {
+    Gson g = new Gson();
+    Event event = null;
+    try {
+      event = g.fromJson(json, Event.class);
+    } catch (JsonSyntaxException e) {
+      throw new InvalidJsonException(Event.class.getSimpleName());
+    }
+    return event;
   }
 }

--- a/src/test/java/core/response/MessageResponseTest.java
+++ b/src/test/java/core/response/MessageResponseTest.java
@@ -1,14 +1,21 @@
 package core.response;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
 import com.google.gson.Gson;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import net.hawry.messaging.core.response.MessageResponse;
+import net.hawry.messaging.exceptions.InvalidJsonException;
 
 @DisplayName("MessageResponse tests")
 class MessageResponseTest {
@@ -38,5 +45,43 @@ class MessageResponseTest {
   @DisplayName("returns no errors")
   void noErrors() {
     assertFalse(mr.hasErrors());
+  }
+
+  @Test
+  @DisplayName("message response fromJson returns a valid instance")
+  void fromJson_Valid() {
+    String json = "{'recipient_id': '123','message_id':'$mid.id'}";
+    MessageResponse rsp = null;
+    
+    try {
+      rsp = MessageResponse.fromJson(json);
+    } catch (InvalidJsonException e) {
+      Assertions.fail("exception thrown: " + e.getMessage());
+    }
+
+    assertEquals("$mid.id", rsp.getMessageId());
+    assertEquals("123", rsp.getRecipientId());
+  }
+
+  @Test
+  @DisplayName("message response fromJson returns a valid error")
+  void fromJson_ValidError() {
+    String json = "{'error':{'code':100}}";
+
+    MessageResponse rsp = null;
+    try {
+      rsp = MessageResponse.fromJson(json);
+    } catch (InvalidJsonException e) {
+      Assertions.fail("exception thrown: " + e.getMessage());
+    }
+    assertTrue(rsp.hasErrors());
+    assertNotNull(rsp.getError());
+  }
+
+  @Test
+  @DisplayName("invalid json throws exception")
+  void fromJson_InvalidJson() {
+    String json = "{'recipient_id':123";
+    assertThrows(InvalidJsonException.class, () -> { MessageResponse.fromJson(json); });
   }
 }

--- a/src/test/java/core/webhook/EventTest.java
+++ b/src/test/java/core/webhook/EventTest.java
@@ -1,14 +1,17 @@
 package core.webhook;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import com.google.gson.Gson;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import net.hawry.messaging.core.webhook.Event;
+import net.hawry.messaging.exceptions.InvalidJsonException;
 
 @DisplayName("Event")
 class EventTest {
@@ -32,5 +35,28 @@ class EventTest {
   @DisplayName("returns entry array")
   void validEntryArray() {
     assertEquals(2, event.getEntries().length);
+  }
+
+  @Test
+  @DisplayName("returns valid Event object from valid json")
+  void fromJson_ValidData() {
+    String json = "{'object':'page', 'entry': [{'id':'123','time':12344444,'messaging': []}]}";
+    Event event = null;
+
+    try {
+      event = Event.fromJson(json);
+    } catch (InvalidJsonException e) {
+      Assertions.fail("exception thrown: " + e.getMessage());
+    }
+
+    assertEquals("page", event.getObject());
+    assertEquals(1, event.getEntries().length);
+  }
+
+  @Test
+  @DisplayName("throws exception if invalid JSON")
+  void fromJson_InvalidData() {
+    String json = "{'object':'page' 'entry': [{'id':'123','time':12344444,'messaging': []}]}";
+    assertThrows(InvalidJsonException.class, () -> { Event.fromJson(json); });
   }
 }


### PR DESCRIPTION
* Add static `fromJson(String json)`-method to classes:
  * `Event`
  * `MessageResponse`
* Test cases for the above method(s)